### PR TITLE
fix: no edge in linux

### DIFF
--- a/install_apps.sh
+++ b/install_apps.sh
@@ -50,7 +50,7 @@ sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/micros
 ## Install
 sudo rm microsoft.gpg
 sudo apt update
-sudo apt install -y microsoft-edge-stable code
+sudo apt install -y code
 
 # Spotube - Spotify open-source alternative
 wget https://github.com/KRTirtho/spotube/releases/latest/download/Spotube-linux-x86_64.deb


### PR DESCRIPTION
This PR removes the installation of Microsoft Edge from the Mint setup script. The package was previously included as part of the default setup, but it is no longer necessary or desired. This update ensures that only the essential packages are installed for a streamlined setup process.

### Changes:
- Removed Microsoft Edge installation step from the script

This update aligns the script with the current requirements for a clean Mint installation setup.
